### PR TITLE
[TECHNICAL-SUPPORT] LPS-47661 ArrayIndexOutOfBoundsException occurs during content edition if the Structure has been edited

### DIFF
--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/util/DDMXSDImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/util/DDMXSDImpl.java
@@ -137,6 +137,8 @@ public class DDMXSDImpl implements DDMXSD {
 		String[] fieldsDisplayValues = getFieldsDisplayValues(
 			fieldDisplayValue);
 
+		int offset = 0;
+
 		boolean fieldDisplayable = ArrayUtil.contains(
 			fieldsDisplayValues, name);
 
@@ -147,7 +149,12 @@ public class DDMXSDImpl implements DDMXSD {
 
 			String parentFieldName = (String)parentFieldStructure.get("name");
 
-			int offset = ddmFieldsCounter.get(DDMImpl.FIELDS_DISPLAY_NAME);
+			offset = getFieldOffset(
+				fieldsDisplayValues, name, ddmFieldsCounter.get(name));
+
+			if (offset == fieldsDisplayValues.length) {
+				return StringPool.BLANK;
+			}
 
 			fieldRepetition = countFieldRepetition(
 				fieldsDisplayValues, parentFieldName, offset);
@@ -156,11 +163,14 @@ public class DDMXSDImpl implements DDMXSD {
 		StringBundler sb = new StringBundler(fieldRepetition);
 
 		while (fieldRepetition > 0) {
+			offset = getFieldOffset(
+				fieldsDisplayValues, name, ddmFieldsCounter.get(name));
+
 			String fieldNamespace = StringUtil.randomId();
 
 			if (fieldDisplayable) {
 				fieldNamespace = getFieldNamespace(
-					fieldDisplayValue, ddmFieldsCounter);
+					fieldDisplayValue, ddmFieldsCounter, offset);
 			}
 
 			fieldStructure.put("fieldNamespace", fieldNamespace);
@@ -169,7 +179,6 @@ public class DDMXSDImpl implements DDMXSD {
 
 			if (fieldDisplayable) {
 				ddmFieldsCounter.incrementKey(name);
-				ddmFieldsCounter.incrementKey(DDMImpl.FIELDS_DISPLAY_NAME);
 			}
 
 			String childrenHTML = getHTML(
@@ -683,16 +692,33 @@ public class DDMXSDImpl implements DDMXSD {
 	}
 
 	protected String getFieldNamespace(
-		String fieldDisplayValue, DDMFieldsCounter ddmFieldsCounter) {
+		String fieldDisplayValue, DDMFieldsCounter ddmFieldsCounter,
+		int offset) {
 
 		String[] fieldsDisplayValues = StringUtil.split(fieldDisplayValue);
-
-		int offset = ddmFieldsCounter.get(DDMImpl.FIELDS_DISPLAY_NAME);
 
 		String fieldsDisplayValue = fieldsDisplayValues[offset];
 
 		return StringUtil.extractLast(
 			fieldsDisplayValue, DDMImpl.INSTANCE_SEPARATOR);
+	}
+
+	protected int getFieldOffset(
+		String[] fieldsDisplayValues, String name, int index) {
+
+		int offset = 0;
+
+		for (; offset < fieldsDisplayValues.length; offset++) {
+			if (name.equals(fieldsDisplayValues[offset])) {
+				index--;
+
+				if (index < 0) {
+					break;
+				}
+			}
+		}
+
+		return offset;
 	}
 
 	protected Map<String, Map<String, Object>> getFieldsContext(


### PR DESCRIPTION
Hi Marcellus, @juliocamarero,

this issue is strictly related to DDM Structures, however, it affects to WCM, Documents and Media and Dynamic Data Lists as well.

The problem is the following: 
if there is already an existing content created from a structure, modifying the structure could cause  serious problems. Although on the UI we have a warning message during the structure edition ("There are content references to this structure. You may lose data if a field name is renamed or removed."),  in unlucky cases ArrayIndexOutOfBoundsException  occurs when we try to edit the content and the fields don't render properly.

Despite the fact that it is not recommended to edit a structure which is already used, I think the portal should handle more robustly these cases.

Right now the behavior is unpredictable, as the process tries to go through the fields 
sequentially, using the the new order coming from the structure, but the content's fields remained the same.

Changing a structure with many repeatable and/or child fields creates a complex problem, as it is not easy to restore the content after it. Imagine a structure with two repeatable parent/child fields than switch them, so the child field became the parent field...
Even though probably nobody would like to complicate his life so badly,  in my opinion, the portal should have some kind of fallback logic. 

My idea is the following:
While we are processing the fields with the order coming from the structure, search for the first unprocessed field with the same name.  According to my tests this fix solves the problem when the fields are switched at the same level. Furthermore a simple check prevents the ArrayIndexOutOfBoundsException, so the content remains editable.

Could you please review my changes? How we should handle this problem?
If I missed something, or you have a better idea, please point me to the right direction.

Thank you in advance,
Tamás
